### PR TITLE
Fix genetic and deprecations

### DIFF
--- a/R/genetic_alg.R
+++ b/R/genetic_alg.R
@@ -54,7 +54,7 @@ genetic = function(model,alg,data,K,verbose=FALSE){
     }
     children = as.list(children)
     for (i in 1:(alg@pop_size-1)){
-      if(stats::runif(1)<alg@prob_mut){
+      if(stats::runif(1)<alg@prob_mutation){
         new_solutions[[i]] %<-% fit_greed(model,data,children[[i]]@cl,"swap",1)
       }else{
         new_solutions[[i]] = children[[i]]

--- a/R/plot.R
+++ b/R/plot.R
@@ -231,10 +231,10 @@ graph_blocks = function(x){
     ggplot2::ggtitle(paste0(toupper(x@model@name)," model with : ",max(x@cl)," clusters."))+
     ggplot2::scale_x_continuous("",breaks=cumsum(x@obs_stats$counts),
                                 labels = ifelse(x@obs_stats$counts/sum(x@obs_stats$counts)>0.05,paste0(round(100*x@obs_stats$counts/sum(x@obs_stats$counts)),"%"),""),
-                                minor_breaks = NULL,expand = ggplot2::expand_scale(mult = 0, add = 0))+
+                                minor_breaks = NULL,expand = ggplot2::expansion(mult = 0, add = 0))+
     ggplot2::scale_y_continuous("",breaks=cumsum(x@obs_stats$counts),
                                 labels = ifelse(x@obs_stats$counts/sum(x@obs_stats$counts)>0.05,paste0(round(100*x@obs_stats$counts/sum(x@obs_stats$counts)),"%"),""),
-                                minor_breaks = NULL,expand = ggplot2::expand_scale(mult = 0, add = 0))+
+                                minor_breaks = NULL,expand = ggplot2::expansion(mult = 0, add = 0))+
     ggplot2::coord_fixed()+ggplot2::theme_bw()
 }
 
@@ -256,8 +256,8 @@ co_blocks = function(x){
     ggplot2::scale_fill_distiller("E[X]",palette="YlOrRd",direction = 1,guide = ggplot2::guide_legend(),limits=c(0,max(gg$count/(gg$sizek*gg$sizel))))+
     ggplot2::scale_alpha("E[X]",range=c(0,1),limits=c(0,max(gg$count/(gg$sizek*gg$sizel))))+
     ggplot2::ggtitle(paste0("Co-clustering with : ",max(x@cl)," clusters."))+
-    ggplot2::scale_x_continuous("Col clusters",breaks=cccol,labels=ifelse(ylab>5,paste0(ylab,"%"),""),minor_breaks = NULL,expand = ggplot2::expand_scale(mult = 0, add = 0))+
-    ggplot2::scale_y_continuous("Row clusters",breaks=ccrow,labels =ifelse(xlab>5,paste0(xlab,"%"),""),minor_breaks = NULL,expand = ggplot2::expand_scale(mult = 0, add = 0))+
+    ggplot2::scale_x_continuous("Col clusters",breaks=cccol,labels=ifelse(ylab>5,paste0(ylab,"%"),""),minor_breaks = NULL,expand = ggplot2::expansion(mult = 0, add = 0))+
+    ggplot2::scale_y_continuous("Row clusters",breaks=ccrow,labels =ifelse(xlab>5,paste0(xlab,"%"),""),minor_breaks = NULL,expand = ggplot2::expansion(mult = 0, add = 0))+
     ggplot2::theme_bw()      
 }
 
@@ -274,8 +274,8 @@ mat_blocks = function(x){
     ggplot2::scale_fill_distiller("E[X]",palette="YlOrRd",direction = 1,guide = ggplot2::guide_legend(),limits=c(1,log(max(gg$count))))+
     ggplot2::scale_alpha("E[X]",range=c(0,1),limits=c(0,max(gg$count)))+
     ggplot2::ggtitle(paste0("MM Model with : ",max(x@cl)," clusters."))+
-    ggplot2::scale_x_continuous("Features",breaks=1:D,labels=rep("",D),minor_breaks = NULL,expand = ggplot2::expand_scale(mult = 0, add = 0))+
-    ggplot2::scale_y_continuous("Clusters",breaks=cumsum(x@obs_stats$counts),labels = paste0(round(100*x@obs_stats$counts/sum(x@obs_stats$counts)),"%"),minor_breaks = NULL,expand = ggplot2::expand_scale(mult = 0, add = 0))+
+    ggplot2::scale_x_continuous("Features",breaks=1:D,labels=rep("",D),minor_breaks = NULL,expand = ggplot2::expansion(mult = 0, add = 0))+
+    ggplot2::scale_y_continuous("Clusters",breaks=cumsum(x@obs_stats$counts),labels = paste0(round(100*x@obs_stats$counts/sum(x@obs_stats$counts)),"%"),minor_breaks = NULL,expand = ggplot2::expansion(mult = 0, add = 0))+
     ggplot2::theme_bw()      
 }
 

--- a/tests/testthat/test_sbm.R
+++ b/tests/testthat/test_sbm.R
@@ -68,3 +68,20 @@ test_that("SBM multitstart", {
   expect_true(is.ggplot(plot(solc,type='blocks')))
   expect_true(is.ggplot(plot(solc,type='nodelink')))
 })
+
+test_that("SBM genetic", {
+  N = 500
+  K = 10
+  pi = rep(1/K,K)
+  mu = diag(rep(1/5,K))+runif(K*K)*0.01
+  sbm = rsbm(N,pi,mu)
+  sol=greed(sbm$x,model=new('sbm'),alg=new("genetic"))
+  expect_gte(sol@K, K-2)
+  expect_lte(sol@K, K+2)
+  solc = cut(sol,8)
+  expect_true(is.ggplot(plot(solc,type='tree')))
+  expect_true(is.ggplot(plot(solc,type='path')))
+  expect_true(is.ggplot(plot(solc,type='front')))
+  expect_true(is.ggplot(plot(solc,type='blocks')))
+  expect_true(is.ggplot(plot(solc,type='nodelink')))
+})

--- a/tests/testthat/test_sbm.R
+++ b/tests/testthat/test_sbm.R
@@ -52,7 +52,7 @@ test_that("SBM seed", {
 })
 
 
-test_that("SBM seed", {
+test_that("SBM multitstart", {
   N = 500
   K = 10
   pi = rep(1/K,K)


### PR DESCRIPTION
Hello Etienne,

Voici une pull request assez mineure, il y a 2 petits fix : 

 1. Corrige une ligne du fichier genetic_alg.R avec une typo : le slot `alg@prob_mut` n'existe pas donc il renvoyait une erreur. J'ai modifié en `alg@prob_mutation`. J'en ai profité pour rajouter un unittest pour l'algo génétique en plus de ceux existants (uniquement pour le SBM pour l'instant, je préferais ne pas trop te modifier de choses). 

 2. Modifie les appels à `ggplot2::expand_scale()` en `ggplot2::expansion()` pour éviter les `deprecated warnings` de ggplot2.

Dans les trucs mineurs que j'ai remarqué c'est qu'il y a une fonction auxiliaire qui fait un test `if (class(X) == "matrix")` au mieux de `is(X, "matrix')` quelque part. Si on met en input un objet qui à un `class(X)` de taille supérieure à 1, ça nous fait des warnings partout `la condition a une longueur > 1 et seul le premier élément est utilisé`. Mais j'ai vérifié et ça ne vient pas du package, ça doit être dans une fonction auxiliaire d'un autre package que je n'arrive pas à identifier. A voir si on peut s'en passer. 