### PR TITLE
Squash commit : modifications Nicolas de lca.r + cut() + postprocess()

### DIFF
--- a/R/alg_classes.R
+++ b/R/alg_classes.R
@@ -90,10 +90,21 @@ setMethod(f = "cut",
           definition = function(x, K){
             if(K<x@K){
               i = which(sapply(x@path,function(p){p$K})==K)
+              # Old version: x@cl = as.vector(x@path[[i]]$cl) 
+              # Compute cl with the history of fusions (k,l) at each stage
+              for(p in 1:i) {
+                # Get fusion (k,l)
+                k = x@path[[p]]$k
+                l = x@path[[p]]$l
+                x@cl[x@cl == k] = l
+                # rescale @cl to be 1...K
+                x@cl = as.integer(factor(x@cl))
+              }
               x@K = K
               x@logalpha=x@path[[i]]$logalpha
               x@icl = x@path[[i]]$icl
-              x@cl = as.vector(x@path[[i]]$cl)
+   
+              
               for(st in names(x@obs_stats)){
                 x@obs_stats[st] = x@path[[i]]$obs_stats[st]
               }

--- a/R/coclust_dcsbm.R
+++ b/R/coclust_dcsbm.R
@@ -126,7 +126,16 @@ setMethod(f = "cut",
               x@K = K
               x@logalpha=x@path[[i]]$logalpha
               x@icl = x@path[[i]]$icl
-              x@cl = as.vector(x@path[[i]]$cl)
+              # Old version: x@cl = as.vector(x@path[[i]]$cl) 
+              # Compute cl with the history of fusions (k,l) at each stage
+              for(p in 1:i) {
+                # Get fusion (k,l)
+                k = x@path[[p]]$k
+                l = x@path[[p]]$l
+                x@cl[x@cl == k] = l
+                # rescale @cl to be 1...K
+                x@cl = as.integer(factor(x@cl))
+              }
               for(st in names(x@path[[i]]$obs_stats)){
                 x@obs_stats[st] = x@path[[i]]$obs_stats[st]
               }
@@ -255,7 +264,7 @@ setMethod(f = "preprocess",
 
 setMethod(f = "postprocess", 
           signature = signature("co_dcsbm_path"), 
-          definition = function(path,data=NULL){
+          definition = function(path,data=NULL,X=NULL,Y=NULL){
             sol = path
             if(!is.null(data)){
               sol@Nrow = data$Nrows

--- a/src/IclModel.cpp
+++ b/src/IclModel.cpp
@@ -498,13 +498,14 @@ List IclModel::greedy_merge_path(){
     // store current solution
 
     path.push_back(List::create(Named("obs_stats") = this->get_obs_stats(), 
-                                Named("cl") = cl+1, 
                                 Named("K") = K,
                                 Named("icl1")=icl,
                                 Named("logalpha")=icl-iclold,
                                 Named("k")=k+1,
                                 Named("l")=l+1,
+                                // useless? : 
                                 Named("merge_mat") = arma::trimatl(merge_mat.getMergeMat())));
+                                
     // update merge matrix
     merge_mat = this->delta_merge(merge_mat.getMergeMat(),merge_mat.getK(),merge_mat.getL(),old_stats);
   }

--- a/tests/testthat/test_lca.R
+++ b/tests/testthat/test_lca.R
@@ -16,6 +16,8 @@ test_that("LCA sim",{
   
   sol=greed(lca.data$x,model=new("lca"),alg=new("hybrid",pop_size=100),K=10)
   sol@icl
+  sol@obs_stats$counts
+  sol@obs_stats$x_counts
   table(sol@cl,lca.data$cl)
   model=new("lca",beta=5)
   data=greed:::preprocess(model,lca.data$x)


### PR DESCRIPTION
Voilà les modifs pour 
 * LCA : `postprocess()` qui clean le slot @obs_stats pour avoir une liste à un seul niveau.
 * La fonction `cut()` qui recalcule le slot @cl à n'importe quel étage de la hiérarchie (à vérifier pour le coclustering quand même).

Toutes les modifs sont comprises dans un gros commit (squash commit) pour plus de lisibilité de l'historique.

Nicolas