### PR TITLE
Updating RcppArmadillo initialization

### DIFF
--- a/src/DcSbm.cpp
+++ b/src/DcSbm.cpp
@@ -206,10 +206,8 @@ double DcSbm::delta_merge_correction(int k,int l,int obk,int obl,const List & ol
   arma::vec old_counts =as<arma::vec>(old_stats["counts"]);
   arma::mat old_x_counts =as<arma::mat>(old_stats["x_counts"]);
   cc = counts(k)*counts(l);
-  arma::uvec kl;
-  kl << k << l << arma::endr;
-  arma::uvec mkl;
-  mkl << obk << obl << arma::endr;
+  arma::uvec kl({k, l});
+  arma::uvec mkl({ obk, obl});
   if(l>=obk){
     lo=l+1;
   }else{

--- a/src/DcSbmUndirected.cpp
+++ b/src/DcSbmUndirected.cpp
@@ -87,10 +87,8 @@ double DcSbmUndirected::delta_merge_correction(int k,int l,int obk,int obl,const
   arma::vec old_counts =as<arma::vec>(old_stats["counts"]);
   arma::mat old_x_counts =as<arma::mat>(old_stats["x_counts"]);
   cc = counts(k)*counts(l);
-  arma::uvec kl;
-  kl << k << l << arma::endr;
-  arma::uvec mkl;
-  mkl << obk << obl << arma::endr;
+  arma::uvec kl({k, l});
+  arma::uvec mkl({obk, obl});
   if(l>=obk){
     lo=l+1;
   }else{

--- a/src/MultSbm.cpp
+++ b/src/MultSbm.cpp
@@ -194,10 +194,8 @@ double MultSbm::delta_merge_correction(int k,int l,int obk,int obl,const List & 
   arma::cube old_x_counts =as<arma::cube>(old_stats["x_counts"]);
   arma::vec klcounts;
 
-  arma::uvec kl;
-  kl << k << l << arma::endr;
-  arma::uvec mkl;
-  mkl << obk << obl << arma::endr;
+  arma::uvec kl({k, l});
+  arma::uvec mkl({obk, obl});
   if(l>=obk){
     lo=l+1;
   }else{

--- a/src/MultSbmUndirected.cpp
+++ b/src/MultSbmUndirected.cpp
@@ -73,10 +73,8 @@ double MultSbmUndirected::delta_merge_correction(int k,int l,int obk,int obl,con
   double oxc,xc;
   arma::cube old_x_counts =as<arma::cube>(old_stats["x_counts"]);
   arma::vec klcounts;
-  arma::uvec kl;
-  kl << k << l << arma::endr;
-  arma::uvec mkl;
-  mkl << obk << obl << arma::endr;
+  arma::uvec kl({k, l});
+  arma::uvec mkl({obk, obl});
   if(l>=obk){
     lo=l+1;
   }else{

--- a/src/Sbm.cpp
+++ b/src/Sbm.cpp
@@ -149,10 +149,8 @@ double Sbm::delta_merge_correction(int k,int l,int obk,int obl,const List & old_
   arma::vec old_counts =as<arma::vec>(old_stats["counts"]);
   arma::mat old_x_counts =as<arma::mat>(old_stats["x_counts"]);
   cc = counts(k)*counts(l);
-  arma::uvec kl;
-  kl << k << l << arma::endr;
-  arma::uvec mkl;
-  mkl << obk << obl << arma::endr;
+  arma::uvec kl({k, l});
+  arma::uvec mkl({obk, obl});
   if(l>=obk){
     lo=l+1;
   }else{

--- a/src/SbmUndirected.cpp
+++ b/src/SbmUndirected.cpp
@@ -59,10 +59,8 @@ double SbmUndirected::delta_merge_correction(int k,int l,int obk,int obl,const L
   arma::vec old_counts =as<arma::vec>(old_stats["counts"]);
   arma::mat old_x_counts =as<arma::mat>(old_stats["x_counts"]);
   cc = counts(k)*counts(l);
-  arma::uvec kl;
-  kl << k << l << arma::endr;
-  arma::uvec mkl;
-  mkl << obk << obl << arma::endr;
+  arma::uvec kl({k, l});
+  arma::uvec mkl({obk, obl});
   if(l>=obk){
     lo=l+1;
   }else{


### PR DESCRIPTION
These six two-line changes update RcppArmadillo from the now
deprecated `<<` initialization to brace initialization allowed since
C++11 and long been the minimal standard with R too.  It would be
great if you could merge this, and release and updated package "in the
next little while" -- see the two prior emails I sent, and the
transition log at RcppCore/RcppArmadillo#391